### PR TITLE
Improve handling of `sys.version_info` branches inside class scopes

### DIFF
--- a/add_docstrings.py
+++ b/add_docstrings.py
@@ -468,6 +468,8 @@ STDLIB_MODULE_BLACKLIST = frozenset(
 
 STDLIB_OBJECT_BLACKLIST = frozenset(
     {
+        # On older Python versions, `enum.auto.value` is just an instance of `object`;
+        # we don't want docstring-adder to add the docstring from `object` to it.
         "enum.auto.value",
     }
 )

--- a/add_docstrings.py
+++ b/add_docstrings.py
@@ -377,10 +377,7 @@ def add_docstrings_to_stub(
 
     if runtime_module.__doc__ and parsed_module.get_docstring() is None:
         docstring = '"""\n' + clean_docstring(runtime_module.__doc__) + '\n"""\n'
-        if stub_source.strip():
-            stub_source = docstring + stub_source
-        else:
-            stub_source = docstring
+        stub_source = docstring + stub_source if stub_source.strip() else docstring
         parsed_module = libcst.parse_module(stub_source)
 
     transformer = DocstringAdder(
@@ -426,9 +423,9 @@ def check_no_destructive_changes(path: Path, previous_stub: str, new_stub: str) 
     new_checker = SanityChecker()
     new_checker.visit(new_ast)
 
-    assert (
-        previous_checker.names == new_checker.names
-    ), f"Destructive changes appear to have been made to {path}"
+    assert previous_checker.names == new_checker.names, (
+        f"Destructive changes appear to have been made to {path}"
+    )
 
 
 def install_typeshed_packages(typeshed_paths: Sequence[Path]) -> None:
@@ -457,22 +454,18 @@ def install_typeshed_packages(typeshed_paths: Sequence[Path]) -> None:
 # * `__main__` exists at runtime but will just reflect details of how docstring-adder itself was run.
 # * `sys._monitoring` exists as `sys.monitoring` at runtime, but none of the APIs in that module
 #   have docstrings, so no point trying to add them.
-STDLIB_MODULE_BLACKLIST = frozenset(
-    {
-        "_typeshed/*.pyi",
-        "antigravity.pyi",
-        "__main__.pyi",
-        "sys/_monitoring.pyi",
-    }
-)
+STDLIB_MODULE_BLACKLIST = frozenset({
+    "_typeshed/*.pyi",
+    "antigravity.pyi",
+    "__main__.pyi",
+    "sys/_monitoring.pyi",
+})
 
-STDLIB_OBJECT_BLACKLIST = frozenset(
-    {
-        # On older Python versions, `enum.auto.value` is just an instance of `object`;
-        # we don't want docstring-adder to add the docstring from `object` to it.
-        "enum.auto.value",
-    }
-)
+STDLIB_OBJECT_BLACKLIST = frozenset({
+    # On older Python versions, `enum.auto.value` is just an instance of `object`;
+    # we don't want docstring-adder to add the docstring from `object` to it.
+    "enum.auto.value"
+})
 
 
 def load_blacklist(path: Path) -> frozenset[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -310,15 +310,15 @@ wheels = [
 
 [[package]]
 name = "typeshed-client"
-version = "2.7.0"
+version = "2.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/1e/f20e33447be772486acf028295cdd21437454a051adb602d52ddb5334f9e/typeshed_client-2.7.0.tar.gz", hash = "sha256:e63df1e738588ad39f1226de042f4407ab6a99c456f0837063afd83b1415447c", size = 433569, upload-time = "2024-07-16T17:01:17.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/4074d3505b4700a6bf13cb1bb2d1848bb8c78e902e3f9fe5916274c5d284/typeshed_client-2.8.2.tar.gz", hash = "sha256:9d8e29fb74574d87bf9a719f77131dc40f2aeea20e97d25d4a3dc2cc30debd31", size = 501617, upload-time = "2025-07-16T01:49:49.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/39/4702c2901899c018189b9aa7eb75aa8eb54527aed71c3f285895190dc664/typeshed_client-2.7.0-py3-none-any.whl", hash = "sha256:97084e5abc58a76ace2c4618ecaebd625f2d19bbd85aa1b3fb86216bf174bbea", size = 624417, upload-time = "2024-07-16T17:01:15.246Z" },
+    { url = "https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl", hash = "sha256:4cf886d976c777689cd31889f13abf5bfb7797c82519b07e5969e541380c75ee", size = 760467, upload-time = "2025-07-16T01:49:47.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Currently if we see an `if sys.version_info >= (3, 12)` branch in the global scope, we're very good at adding the `>=3.12` docstring for the if-true branch and the `<3.12` docstring for the if-false branch. But if we have an `if sys.version_info >= (3, 12)` branch in a class scope, we just add the 3.12 docstring to both branches. This PR fixes that. I tested locally extensively, and it has the following effects:
- Adds several missing docstrings for version-dependent APIs
- Improves the accuracy of docstrings on lower Python versions: they are now less likely to mention parameters that don't yet exist (because they were added on later versions)
- Removes some docstrings that don't actually exist at runtime on subclasses but that docstring-adder was incorrectly picking up from superclasses
- Does some funny things to formatting in a couple of docstrings in `os/__init__.pyi` and `smtplib.pyi`. I'm not totally sure why this is, but I don't think it will affect ty's ability to render these docstrings, so I don't think it's a big issue.