### PR TITLE
Use public API from typeshed_client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "libcst>=1.8.2",
     "termcolor>=3.1.0",
     "tomli>=2.2.1",
-    "typeshed-client>=2.8.2",
+    "typeshed-client @ git+https://github.com/JelleZijlstra/typeshed_client@dc933baf47b3df4bbaf4e3f2d6a1fe238e6c7c68",
     # So that we can add docs for `typing_extensions` APIs:
     "typing_extensions",
 ]
@@ -44,6 +44,9 @@ add-docstrings = "add_docstrings:main"
 
 [tool.hatch.build.targets.wheel]
 include = ["add_docstrings.py"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [dependency-groups]
 dev = ["mypy==1.17.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ requires-dist = [
     { name = "libcst", specifier = ">=1.8.2" },
     { name = "termcolor", specifier = ">=3.1.0" },
     { name = "tomli", specifier = ">=2.2.1" },
-    { name = "typeshed-client", specifier = ">=2.8.2" },
+    { name = "typeshed-client", git = "https://github.com/JelleZijlstra/typeshed_client?rev=dc933baf47b3df4bbaf4e3f2d6a1fe238e6c7c68" },
     { name = "typing-extensions" },
 ]
 
@@ -311,14 +311,10 @@ wheels = [
 [[package]]
 name = "typeshed-client"
 version = "2.8.2"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/JelleZijlstra/typeshed_client?rev=dc933baf47b3df4bbaf4e3f2d6a1fe238e6c7c68#dc933baf47b3df4bbaf4e3f2d6a1fe238e6c7c68" }
 dependencies = [
     { name = "importlib-resources" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/4074d3505b4700a6bf13cb1bb2d1848bb8c78e902e3f9fe5916274c5d284/typeshed_client-2.8.2.tar.gz", hash = "sha256:9d8e29fb74574d87bf9a719f77131dc40f2aeea20e97d25d4a3dc2cc30debd31", size = 501617, upload-time = "2025-07-16T01:49:49.299Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl", hash = "sha256:4cf886d976c777689cd31889f13abf5bfb7797c82519b07e5969e541380c75ee", size = 760467, upload-time = "2025-07-16T01:49:47.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This has no impact on the docstrings we codemod into the stubs, but it's nice to use public API rather than private implementation details. I'm switching to a git dependency of typeshed_client so @JelleZijlstra doesn't have to keep cutting releases for us :-)