### PR TITLE
Remove `--exit-zero` CLI flag

### DIFF
--- a/add_docstrings.py
+++ b/add_docstrings.py
@@ -622,12 +622,6 @@ def main() -> None:
         ),
         default=(),
     )
-    parser.add_argument(
-        "-z",
-        "--exit-zero",
-        action="store_true",
-        help="Exit with code 0 even if there were errors.",
-    )
     args = parser.parse_args()
 
     stdlib_path = Path(args.stdlib_path) if args.stdlib_path else None


### PR DESCRIPTION
It doesn't actually make docstring-adder exit with code 0; it doesn't do anything at all right now... and it's not very useful. If you want to ignore the return code, you can just do `|| true` on the CLI!