### PR TITLE
Have renovate update ty on a daily basis

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   dependencyDashboard: true,
   suppressNotifications: ["prEditedNotification"],
   extends: ["config:recommended"],
-  schedule: ["before 4am on Monday"],
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,
@@ -19,17 +18,20 @@
     {
       matchDepTypes: ["action"],
       pinDigests: true,
+      schedule: ["before 4am on Monday"],
     },
     // Annotate GitHub Actions SHAs with a SemVer version.
     {
       extends: ["helpers:pinGitHubActionDigests"],
       extractVersion: "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
       versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+      schedule: ["before 4am on Monday"],
     },
     {
-      groupName: "Artifact GitHub Actions dependencies",
+      groupName: "GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       description: "Weekly update of GitHub Action dependencies",
+      schedule: ["before 4am on Monday"],
     },
     {
       // This package rule disables updates for GitHub runners:
@@ -40,11 +42,27 @@
       matchDatasources: ["github-runners"],
       description: "Disable PRs updating GitHub runners (e.g. 'runs-on: macos-14')",
       enabled: false,
+      schedule: ["before 4am on Monday"],
     },
     {
       groupName: "pre-commit dependencies",
       matchManagers: ["pre-commit"],
       description: "Weekly update of pre-commit dependencies",
+      schedule: ["before 4am on Monday"],
+    },
+    {
+      groupName: "pyproject.toml dependencies",
+      matchManagers: ["pep621"],
+      matchPackageNames: ["!ty"],
+      description: "pyproject.toml dependencies",
+      schedule: ["before 4am on Monday"],
+    },
+    {
+      groupName: "ty",
+      matchManagers: ["pep621"],
+      matchPackageNames: ["ty"],
+      description: "ty",
+      schedule: ["before 4am"],
     },
   ],
   vulnerabilityAlerts: {


### PR DESCRIPTION
I'd like a ty upgrade PR on this repo as soon as it's available, rather than just every Monday. That'll alert us ASAP if there are any dogfooding issues surfaced when attempting to upgrade to the newest version. This PR sets that up.

Tested via

```
% npx --yes --package renovate -- renovate-config-validator
npm warn deprecated @renovatebot/kbpgp@3.0.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated openpgp@5.11.2: This version is deprecated and will no longer receive security patches. Please refer to https://github.com/openpgpjs/openpgpjs/wiki/Updating-from-previous-versions for details on how to upgrade to a newer supported version.
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```