### PR TITLE
Gracefully handle syntax errors in stub files

### DIFF
--- a/add_docstrings.py
+++ b/add_docstrings.py
@@ -934,7 +934,11 @@ def add_docstrings_to_stub(
         return
 
     stub_source = path.read_text(encoding="utf-8")
-    parsed_module = libcst.parse_module(stub_source)
+    try:
+        parsed_module = libcst.parse_module(stub_source)
+    except libcst.ParserSyntaxError as e:
+        log(f"Could not parse '{module_name}' at {path}: {e}")
+        return
 
     if runtime_module.__doc__ and parsed_module.get_docstring() is None:
         docstring = triple_quoted_docstring(runtime_module.__doc__) + "\n"


### PR DESCRIPTION
If libcst fails to parse the stub due to syntax errors, do not abort the work for other files, instead log a warning and continue.

I tested with these files:
```console
$ cat test-stubs/__init__.pyi

def f() -> int None: ...

$ cat test.py
"""This is a test file."""
def f():
    """This is a docstring."""
```

Before, it exited with:

```console
$ python add_docstrings.py -p test-stubs/
Processing test...
Traceback (most recent call last):
  File "add_docstrings.py", line 1291, in <module>
    _main()
    ~~~~~^^
  File "add_docstrings.py", line 1275, in _main
    add_docstrings_to_stub(module, path, context, combined_blacklist)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "add_docstrings.py", line 937, in add_docstrings_to_stub
    parsed_module = libcst.parse_module(stub_source)
  File ".venv/lib/python3.14/site-packages/libcst/_parser/entrypoints.py", line 65, in parse_module
    result = _parse(
        "file_input",
    ...<3 lines>...
        detect_default_newline=True,
    )
  File ".venv/lib/python3.14/site-packages/libcst/_parser/entrypoints.py", line 47, in _parse
    return parse(source_str)
libcst._exceptions.ParserSyntaxError: Syntax Error @ 2:1.
parser error: error at 2:19: expected one of !=, %, &, (, *, **, +, -, ., /, //, :, <, <<, <=, ==, >, >=, >>, @, [, ^, and, if, in, is, not, or, |

def f() -> int None: ...
^
```

After, it logs the error and continues with other files:

```console
$ python add_docstrings.py -p test-stubs/
Processing test...
Could not parse 'test' at test-stubs/__init__.pyi: Syntax Error @ 2:1.
parser error: error at 2:19: expected one of !=, %, &, (, *, **, +, -, ., /, //, :, <, <<, <=, ==, >, >=, >>, @, [, ^, and, if, in, is, not, or, |

def f() -> int None: ...
^

--- Successfully completed the codemod ---
```