### PR TITLE
Add module overrides for runtime docstring lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ and then invoke it using the `add-docstrings` command, or invoke it directly usi
 Consult the module-level docstring in `add_docstrings.py` for more details on how the tool works.
 Run `uvx --from=git+https://github.com/astral-sh/docstring-adder add-docstrings --help` for
 information on the various CLI options the tool supports.
+
+## Module overrides
+
+By default the tool imports the runtime module whose name matches each stub's own dotted
+module name. When a stub's symbols actually live in a different runtime module -- for
+example, extension modules that flatten many logical submodules into a single
+compiled module -- you can redirect the lookup with a `[tool.docstring-adder.module-overrides]`
+table:
+
+```toml
+[tool.docstring-adder.module-overrides]
+"example_package.submodule" = "example_package._runtime"
+"example_package.other_submodule" = "example_package._runtime"
+```
+
+Each entry maps a stub's dotted module name to the runtime module whose docstrings should
+be used instead. The table is auto-discovered from a nearby `pyproject.toml`. The stub's
+own module name is still used for blacklist matching and logging.

--- a/add_docstrings.py
+++ b/add_docstrings.py
@@ -88,6 +88,11 @@ Some miscellaneous details:
       def foo(x: str) -> int: ...
   ```
 
+- Runtime imports can be redirected with `[tool.docstring-adder.module-overrides]`,
+  which maps a stub module name to a runtime module name, e.g.
+  `"example_package.submodule" = "example_package._runtime"`. Overrides are read from
+  nearby `pyproject.toml` files.
+
 """
 
 from __future__ import annotations
@@ -1163,11 +1168,16 @@ def transform(
     stub_file_path: Path,
     typeshed_client_context: typeshed_client.SearchContext,
     blacklisted_objects: frozenset[str],
+    insert_module_docstring: bool = True,
 ) -> str:
     """Add runtime docstrings to stub source and return the transformed source."""
     parsed_module = ast.parse(source)
 
-    if runtime_module.__doc__ and ast.get_docstring(parsed_module, clean=False) is None:
+    if (
+        insert_module_docstring
+        and runtime_module.__doc__
+        and ast.get_docstring(parsed_module, clean=False) is None
+    ):
         docstring = triple_quoted_docstring(runtime_module.__doc__) + "\n"
         source = docstring + source if source.strip() else docstring
         parsed_module = ast.parse(source)
@@ -1189,20 +1199,26 @@ def add_docstrings_to_stub(
     path: Path,
     context: typeshed_client.SearchContext,
     blacklisted_objects: frozenset[str],
+    *,
+    runtime_module_name: str | None = None,
 ) -> None:
     """Add docstrings to a stub module and all functions/classes in it."""
+    import_target = runtime_module_name or module_name
 
     print(f"Processing {module_name}... ", flush=True)
     try:
         # Redirect stdout when importing modules to avoid noisy output from modules like `this`
         with contextlib.redirect_stdout(io.StringIO()):
-            runtime_module = importlib.import_module(module_name)
+            runtime_module = importlib.import_module(import_target)
     except KeyboardInterrupt:
         raise
     # `importlib.import_module("multiprocessing.popen_fork")` crashes with AttributeError on Windows
     # Trying to import serial.__main__ for typeshed's pyserial package will raise SystemExit
     except BaseException as e:
-        log(f'Could not import {module_name}: {type(e).__name__}: "{e}"')
+        override = (
+            "" if import_target == module_name else f" (override for {module_name})"
+        )
+        log(f'Could not import {import_target}{override}: {type(e).__name__}: "{e}"')
         return
 
     stub_source = path.read_text(encoding="utf-8")
@@ -1214,6 +1230,7 @@ def add_docstrings_to_stub(
             stub_file_path=path,
             typeshed_client_context=context,
             blacklisted_objects=blacklisted_objects,
+            insert_module_docstring=import_target == module_name,
         )
     except SyntaxError as e:
         log(f"Could not parse '{module_name}' at {path}: {e}")
@@ -1440,6 +1457,34 @@ def load_blacklist(path: Path) -> frozenset[str]:
     return entries - {""}
 
 
+def load_module_overrides(path: Path) -> dict[str, str]:
+    """Load `[tool.docstring-adder.module-overrides]` from a TOML file."""
+    data = tomli.loads(path.read_text(encoding="utf-8"))
+    table = data.get("tool", {}).get("docstring-adder", {}).get("module-overrides", {})
+    if not isinstance(table, dict) or not all(
+        isinstance(value, str) for value in table.values()
+    ):
+        raise SystemExit(f"Invalid module override in {path}: expected a string table")
+    return {str(key): value for key, value in table.items()}
+
+
+def discover_module_overrides(package_paths: Sequence[Path]) -> dict[str, str]:
+    """Collect module overrides from nearby `pyproject.toml` files."""
+    overrides: dict[str, str] = {}
+    seen: set[Path] = set()
+    for package_path in package_paths:
+        for candidate in (
+            package_path.parent.parent,
+            package_path.parent,
+            package_path,
+        ):
+            pyproject = (candidate / "pyproject.toml").resolve()
+            if pyproject.is_file() and pyproject not in seen:
+                seen.add(pyproject)
+                overrides.update(load_module_overrides(pyproject))
+    return overrides
+
+
 def _main(cli_args: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=RawDescriptionRichHelpFormatter
@@ -1504,9 +1549,12 @@ def _main(cli_args: list[str] | None = None) -> None:
         typeshed=stdlib_path, search_path=search_paths, version=sys.version_info[:2]
     )
 
+    package_module_overrides = discover_module_overrides(all_package_paths)
+
     codemodded_stubs = 0
 
     for module, path in typeshed_client.get_all_stub_files(context):
+        runtime_module_name = None
         if stdlib_path is not None and path.is_relative_to(stdlib_path):
             if any(
                 path.relative_to(stdlib_path).match(pattern)
@@ -1514,12 +1562,16 @@ def _main(cli_args: list[str] | None = None) -> None:
             ):
                 log(f"Skipping {module}: blacklisted module")
                 continue
-            else:
-                add_docstrings_to_stub(module, path, context, stdlib_blacklist)
+            blacklist = stdlib_blacklist
         elif any(path.is_relative_to(p) for p in all_package_paths):
-            add_docstrings_to_stub(module, path, context, combined_blacklist)
+            blacklist = combined_blacklist
+            runtime_module_name = package_module_overrides.get(module)
         else:
             continue
+
+        add_docstrings_to_stub(
+            module, path, context, blacklist, runtime_module_name=runtime_module_name
+        )
         codemodded_stubs += 1
 
     if codemodded_stubs == 0:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,134 @@ def test_load_blacklist_ignores_comments_and_blank_lines(tmp_path: Path) -> None
     })
 
 
+def test_load_module_overrides_parses_table(tmp_path: Path) -> None:
+    """A module-overrides table maps stub module names to runtime modules."""
+
+    config = tmp_path / "pyproject.toml"
+    config.write_text(
+        "[tool.docstring-adder.module-overrides]\n"
+        '"example_package.submodule" = "example_package._runtime"\n'
+        '"example_package.other_submodule" = "example_package._runtime"\n',
+        encoding="utf-8",
+    )
+
+    assert add_docstrings.load_module_overrides(config) == {
+        "example_package.submodule": "example_package._runtime",
+        "example_package.other_submodule": "example_package._runtime",
+    }
+
+
+def test_load_module_overrides_rejects_non_string_value(tmp_path: Path) -> None:
+    """A non-string override value fails loudly rather than being coerced."""
+
+    config = tmp_path / "pyproject.toml"
+    config.write_text(
+        "[tool.docstring-adder.module-overrides]\n"
+        '"example_package.submodule" = ["example_package._runtime"]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        add_docstrings.load_module_overrides(config)
+
+
+def test_discover_module_overrides_reads_nearby_pyproject(tmp_path: Path) -> None:
+    """Overrides are auto-discovered from a nearby pyproject.toml."""
+
+    distribution = tmp_path / "python" / "example_package-stubs"
+    package = distribution / "example_package"
+    package.mkdir(parents=True)
+    (tmp_path / "python" / "pyproject.toml").write_text(
+        "[tool.docstring-adder.module-overrides]\n"
+        '"example_package.submodule" = "example_package._runtime"\n',
+        encoding="utf-8",
+    )
+
+    assert add_docstrings.discover_module_overrides([package]) == {
+        "example_package.submodule": "example_package._runtime"
+    }
+
+
+def _write_override_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module_name: str
+) -> None:
+    """Build an importable runtime module with one documented function."""
+
+    (tmp_path / f"{module_name}.py").write_text(
+        'def f() -> None:\n    """Override docs."""\n', encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+
+def test_main_applies_module_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An override redirects introspection to a different runtime module."""
+
+    runtime_module = "example_package_runtime"
+    _write_override_target(tmp_path, monkeypatch, runtime_module)
+
+    package = tmp_path / "stubs" / "example_package"
+    package.mkdir(parents=True)
+    stub = package / "submodule.pyi"
+    stub.write_text("def f() -> None: ...\n", encoding="utf-8")
+
+    (package.parent / "pyproject.toml").write_text(
+        "[tool.docstring-adder.module-overrides]\n"
+        f'"example_package.submodule" = "{runtime_module}"\n',
+        encoding="utf-8",
+    )
+
+    args = ["--packages", str(package)]
+    with (
+        patch.object(
+            add_docstrings.typeshed_client,  # type: ignore[attr-defined]
+            "get_all_stub_files",
+            return_value=[("example_package.submodule", stub)],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        add_docstrings._main(args)
+
+    assert exc_info.value.code == 0
+    assert '"""Override docs."""' in stub.read_text(encoding="utf-8")
+
+
+def test_main_applies_module_override_to_typeshed_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Overrides are also discovered for --typeshed-packages roots."""
+
+    runtime_module = "example_package_typeshed_runtime"
+    _write_override_target(tmp_path, monkeypatch, runtime_module)
+
+    package = tmp_path / "typeshed-stubs" / "example_package"
+    package.mkdir(parents=True)
+    stub = package / "submodule.pyi"
+    stub.write_text("def f() -> None: ...\n", encoding="utf-8")
+
+    (package.parent / "pyproject.toml").write_text(
+        "[tool.docstring-adder.module-overrides]\n"
+        f'"example_package.submodule" = "{runtime_module}"\n',
+        encoding="utf-8",
+    )
+
+    args = ["--typeshed-packages", str(package)]
+    with (
+        patch.object(add_docstrings, "install_typeshed_packages"),
+        patch.object(
+            add_docstrings.typeshed_client,  # type: ignore[attr-defined]
+            "get_all_stub_files",
+            return_value=[("example_package.submodule", stub)],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        add_docstrings._main(args)
+
+    assert exc_info.value.code == 0
+    assert '"""Override docs."""' in stub.read_text(encoding="utf-8")
+
+
 def test_install_typeshed_packages_rejects_a_directory_without_metadata(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -380,6 +380,33 @@ def test_logical_module_name_is_used_for_blacklist() -> None:
     assert transformed == source
 
 
+def test_module_docstring_not_inserted_when_suppressed() -> None:
+    """A redirected runtime module does not contribute its module docstring."""
+    module = module_from_source(
+        '''\
+        """Runtime module docs."""
+
+        def f() -> None:
+            """Function docs."""
+        '''
+    )
+    source = "def f(): ...\n"
+    context = typeshed_client.get_search_context(
+        version=sys.version_info[:2], platform=sys.platform
+    )
+    result = add_docstrings.transform(
+        source,
+        module,
+        module_name="logical.submodule",
+        stub_file_path=Path("logical/submodule.pyi"),
+        typeshed_client_context=context,
+        blacklisted_objects=frozenset(),
+        insert_module_docstring=False,
+    )
+    assert '"""Runtime module docs."""' not in result
+    assert '"""Function docs."""' in result
+
+
 def test_missing_runtime_class_is_unchanged() -> None:
     """A class absent at runtime is left unchanged."""
     source = textwrap.dedent(


### PR DESCRIPTION
Introduce a [tool.docstring-adder.module-overrides] pyproject.toml table mapping a stub's dotted module name to the runtime module whose docstrings should be used instead. The table is auto-discovered next to each --packages root. The override target's module docstring is not copied into redirected stubs.

Closes #184.