### PR TITLE
Switch to a maintained `prettier` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,8 +73,8 @@ repos:
         priority: 0
       - id: markdownlint-fix
         priority: 2
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 06507ab9500d4a9919b5ebd76d9d5b7074f15c1f # frozen: v3.8.4
     hooks:
       - id: prettier
         exclude_types: ["markdown"]


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier is archived and hasn't been updated in 2 years. This new hook is the one that Ruff uses, is still updated, and also has the benefit that it doesn't mirror alpha/beta versions of prettier, only release versions