### PR TITLE
Enable fixes in the ty pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,4 +93,5 @@ repos:
     rev: 94e5ef6a17c7b84d9c5a45457a66b2c23a13b532 # frozen: v0.0.71
     hooks:
       - id: ty
+        args: [--fix]
         priority: 0


### PR DESCRIPTION
Run the ty pre-commit hook with `--fix` so automatically fixable diagnostics are corrected when the hooks run.