### PR TITLE
Switch to Flit and pin build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core==4.0.2"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "docstring-adder"
@@ -44,11 +44,8 @@ classifiers = [
 [project.scripts]
 add-docstrings = "add_docstrings:_main"
 
-[tool.hatch.build.targets.wheel]
-include = ["add_docstrings.py"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
+[tool.flit.module]
+name = "add_docstrings"
 
 [dependency-groups]
 dev = [
@@ -162,3 +159,11 @@ split-on-trailing-comma = false
 no-build = true
 # The project is installed locally, and typeshed-client is pinned to Git.
 no-binary-package = ["docstring-adder", "typeshed-client"]
+# Pin isolated build environments for this project and its Git-pinned dependency.
+build-constraint-dependencies = [
+    "flit-core==4.0.2",
+    # typeshed-client requires setuptools and wheel, which depends on packaging.
+    "packaging==26.3",
+    "setuptools==84.0.0",
+    "wheel==0.47.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,14 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[manifest]
+build-constraints = [
+    { name = "flit-core", specifier = "==4.0.2" },
+    { name = "packaging", specifier = "==26.3" },
+    { name = "setuptools", specifier = "==84.0.0" },
+    { name = "wheel", specifier = "==0.47.0" },
+]
+
 [[package]]
 name = "ast-serialize"
 version = "0.8.0"


### PR DESCRIPTION
## Summary

- Replace Hatchling with Flit while preserving the existing single-module layout.
- Pin `flit_core` directly in the build-system requirements so Git-based and `uvx` installations use the intended backend version.
- Pin the four packages required by isolated local builds of `docstring-adder` and its Git-pinned `typeshed-client` dependency while preserving the existing source-build protections.