### PR TITLE
Remove duplicate flit-core build constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,9 +175,9 @@ exclude-newer-package = { uv = false }
 no-build = true
 # The project is installed locally, and typeshed-client is pinned to Git.
 no-binary-package = ["docstring-adder", "typeshed-client"]
-# Pin isolated build environments for this project and its Git-pinned dependency.
+# flit-core is pinned in [build-system] above, so it is omitted here.
+# Pin the Git-pinned dependency's isolated build dependencies instead.
 build-constraint-dependencies = [
-    "flit-core==4.0.2",
     # typeshed-client requires setuptools and wheel, which depends on packaging.
     "packaging==26.2",
     "setuptools==83.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,6 @@ uv = false
 
 [manifest]
 build-constraints = [
-    { name = "flit-core", specifier = "==4.0.2" },
     { name = "packaging", specifier = "==26.2" },
     { name = "setuptools", specifier = "==83.0.0" },
     { name = "wheel", specifier = "==0.47.0" },


### PR DESCRIPTION
## Summary

`flit-core` is already pinned in `[build-system].requires`. The duplicate uv build constraint makes Renovate's Flit update PRs require a manual edit. Remove that constraint and update the lockfile manifest, while keeping the build constraints for `typeshed-client`.
